### PR TITLE
Containerize gsb

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+*.*/*.build/*
+Dockerfile
+.gitignore
+.dockerignore
+*.*/*.gsp
+.*.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:latest
+
+RUN apk add --update \
+    python \
+    python-dev \
+    py-pip \
+    && mkdir gemini_solution_builder
+
+WORKDIR gemini_solution_builder/
+
+COPY ./ ./
+
+RUN pip install -r requirements.txt \
+    && pip install -e .
+
+VOLUME example/
+
+CMD gsb

--- a/README.md
+++ b/README.md
@@ -1,6 +1,29 @@
 # gemini_solution_builder
 
-Installation
+## Use dockerize gsb
+
+### manual build gsb image
+
+In any env with docker:
+
+```
+git clone https://github.com/ccmagithub/gemini_solution_builder.git
+cd gemini_solution_builder
+git checkout develop
+docker build -t gsb:0.1a .
+```
+
+Now you get gsb image
+
+### How to use
+
+`docker run -v /<abs_path_to_gsp_dir>/:/gemini_solution_builder/example/ gsb:0.1a gsb --build example/`
+
+<abs_path_to_gsp_dir> means absolut path to the directory of gsp
+
+Now you can see the gsp in the folder
+
+## Installation
 
 checkout gemini solution builder code  
 $ git clone https://github.com/ccmagithub/gemini_solution_builder.git  
@@ -26,4 +49,5 @@ $ pip install -e .
 
 you should have gsb installed.  
 $ gsb -h
+
 


### PR DESCRIPTION
因為每次要 build GSP 還要特地弄個環境太麻煩，所以想辦法讓環境 containerize ，變成單獨一個 container 
讓 build GSP 變成只要拉特定 image ，執行時有對應參數，在任一有 docker 的環境下都可 build 出 gsp